### PR TITLE
Improve TypeScript definition, refactor definition to CommonJS compatible export

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,15 +1,21 @@
 /**
- * Create an array with values that are present in the first array but not additional ones.
- *
- * @param array - The array to compare against.
- * @param values - The arrays with values to be excluded.
- * @returns A new array of filtered values.
- *
- * @example
- *
- * import arrayDiffer from 'array-differ';
- *
- * arrayDiffer([2, 3, 4], [3, 50]);
- * //=> [2, 4]
- */
-export default function arrayDiffer<T>(array: ArrayLike<T>, ...values: ArrayLike<T>[]): T[];
+Create an array with values that are present in the first array but not additional ones.
+
+@param array - The array to compare against.
+@param values - The arrays with values to be excluded.
+@returns A new array of filtered values.
+
+@example
+```
+import arrayDiffer = require('array-differ');
+
+arrayDiffer([2, 3, 4], [3, 50]);
+//=> [2, 4]
+```
+*/
+declare function arrayDiffer<ValueType>(
+	array: ReadonlyArray<ValueType>,
+	...values: ReadonlyArray<ValueType>[]
+): ValueType[];
+
+export = arrayDiffer;

--- a/index.d.ts
+++ b/index.d.ts
@@ -14,8 +14,8 @@ arrayDiffer([2, 3, 4], [3, 50]);
 ```
 */
 declare function arrayDiffer<ValueType>(
-	array: ReadonlyArray<ValueType>,
-	...values: ReadonlyArray<ValueType>[]
+	array: readonly ValueType[],
+	...values: (readonly ValueType[])[]
 ): ValueType[];
 
 export = arrayDiffer;

--- a/index.js
+++ b/index.js
@@ -6,4 +6,3 @@ const arrayDiffer = (array, ...values) => {
 };
 
 module.exports = arrayDiffer;
-module.exports.default = arrayDiffer;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,5 +1,5 @@
-import {expectType} from 'tsd-check';
-import arrayDiffer from '.';
+import {expectType} from 'tsd';
+import arrayDiffer = require('.');
 
 expectType<string[]>(arrayDiffer(['a', 'b', 'c'], ['b'], ['c']));
 expectType<number[]>(arrayDiffer([1, 2, 3], [2], [3]));

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 		"node": ">=6"
 	},
 	"scripts": {
-		"test": "xo && ava && tsd-check"
+		"test": "xo && ava && tsd"
 	},
 	"files": [
 		"index.js",
@@ -28,8 +28,8 @@
 		"exclude"
 	],
 	"devDependencies": {
-		"ava": "^1.2.1",
-		"tsd-check": "^0.3.0",
+		"ava": "^1.4.1",
+		"tsd": "^0.7.2",
 		"xo": "^0.24.0"
 	}
 }


### PR DESCRIPTION
**Breaking change**:

- change signature to accept only `ReadonlyArray` instances instead of `ArrayLike` because current implementation only works with arrays
- refactor definition to CommonJS compatible export