### PR TITLE
Replace array concatenation with spread operator

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const arrayDiffer = (array, ...values) => {
-	const rest = new Set([].concat(...values));
+	const rest = new Set([...values]);
 	return array.filter(element => !rest.has(element));
 };
 


### PR DESCRIPTION
Remove unneeded complexity. I think the original reason for needing this was because of how Node.js 4 [worked](https://github.com/sindresorhus/array-differ/pull/4#issue-67058207).

// @sindresorhus 